### PR TITLE
docker exec -it ... bash -l 使用GINI_ENV=development的时候，会发现gini命令找不到

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get install -y unzip openjdk-7-jre-headless && \
     echo 'export PATH="/usr/local/share/sonar-runner/bin:$PATH"' >> /etc/profile.d/sonar-runner.sh
 
 # Set ENV to "development"
-RUN echo "export GINI_ENV=development">/etc/profile.d/gini.sh
+RUN echo "export GINI_ENV=development" >> /etc/profile.d/gini.sh && \
+    echo 'export PATH="/usr/local/share/gini/bin:$PATH"' >> /etc/profile.d/gini.sh
 
 RUN apt-get -y autoremove && apt-get -y autoclean && apt-get -y clean


### PR DESCRIPTION
docker exec -it ... bash 登录，gini命令找到了，但是GINI_ENV=production
bash的login shell的机制问题，需要将PATH写道/etc/profile.d/gini.sh
